### PR TITLE
Martin: Allow trailing semicolon in structured MIME values

### DIFF
--- a/src/nlmimestring.ml
+++ b/src/nlmimestring.ml
@@ -1135,6 +1135,8 @@ let scan_value_with_parameters_ep_int ?decode s options =
   and parse_rest tl =
     match tl with
         [] -> []
+      | Special ';' :: [] ->
+          [] (* Allow trailing semicolon *)
       | Special ';' :: tl' ->
           parse_params tl'
       | _ ->


### PR DESCRIPTION
Fixes the following:

utop # Nlmimestring.scan_value_with_parameters "text/html; charset=utf-8" [];;
- : string \* (string \* string) list = ("text/html", [("charset", "utf-8")])
  utop # Nlmimestring.scan_value_with_parameters "text/html; charset=utf-8;" [];; (\* trailing semicolon *)
  Exception: Failure "Mimestring.scan_value_with_parameters".

The trailing semicolon case parses to: [Atom "text/html"; Special ';'; Atom "charset"; Special '='; Atom "utf-8"; Special ';']

I stared at the function for a while and I'm pretty sure this change won't affect anything else.
