### PR TITLE
Martin, port over Netsendmail

### DIFF
--- a/src/META
+++ b/src/META
@@ -1,5 +1,5 @@
 name = "netstring-light"
-version = "0.0.0"
+version = "0.0.2"
 description = "Standalone subset of the Netstring library from OCamlnet"
 requires = "unix str bigarray"
 archive(byte) = "netstring-light.cma"

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,10 +35,13 @@ all: nldate.ml nlstring_str.ml
 	$(OCAMLC) -c $(FLAGS) nladdress.ml
 	$(OCAMLC) -c $(FLAGS) nlmime.mli
 	$(OCAMLC) -c $(FLAGS) nlmime.ml
+	$(OCAMLC) -c $(FLAGS) nlsendmail.mli
+	$(OCAMLC) -c $(FLAGS) nlsendmail.ml
 	$(OCAMLC) -a $(FLAGS) -o netstring-light.cma \
 		nldate.cmo nlbuffer.cmo nlchannels.cmo nlencoding.cmo \
 		nlstring_str.cmo nlaux.cmo nlsockaddr.cmo nlstream.cmo \
-		nlurl.cmo nlmimestring.cmo nladdress.cmo nlmime.cmo
+		nlurl.cmo nlmimestring.cmo nladdress.cmo nlmime.cmo \
+		nlsendmail.cmo
 opt: nldate.ml nlstring_str.ml
 	$(OCAMLC) -c $(FLAGS) nldate.mli
 	$(OCAMLOPT) -c $(FLAGS) nldate.ml
@@ -64,16 +67,20 @@ opt: nldate.ml nlstring_str.ml
 	$(OCAMLOPT) -c $(FLAGS) nladdress.ml
 	$(OCAMLC) -c $(FLAGS) nlmime.mli
 	$(OCAMLOPT) -c $(FLAGS) nlmime.ml
+	$(OCAMLC) -c $(FLAGS) nlsendmail.mli
+	$(OCAMLOPT) -c $(FLAGS) nlsendmail.ml
 	$(OCAMLOPT) -a $(FLAGS) -o netstring-light.cmxa \
 		nldate.cmx nlbuffer.cmx nlchannels.cmx nlencoding.cmx \
 		nlstring_str.cmx nlaux.cmx nlsockaddr.cmx nlstream.cmx \
-		nlurl.cmx nlmimestring.cmx nladdress.cmx nlmime.cmx
+		nlurl.cmx nlmimestring.cmx nladdress.cmx nlmime.cmx \
+		nlsendmail.cmx
 doc:
 	mkdir -p ../html
 	ocamldoc -html -d ../html \
 		nldate.mli nlencoding.mli nlstring_str.mli nlaux.mli \
 		nlsockaddr.mli nlbuffer.mli nlchannels.mli nlstream.mli \
-		nlurl.mli nlmimestring.mli nladdress.mli nlmime.mli
+		nlurl.mli nlmimestring.mli nladdress.mli nlmime.mli \
+		nlsendmail.mli
 
 netstring-light.cmxa: opt
 

--- a/src/nlmimestring.mli
+++ b/src/nlmimestring.mli
@@ -904,8 +904,6 @@ val split_mime_type : string -> (string * string)
 
 (** {1:printers_for_structured_values Printing Structured Values} *)
 
-(* REMOVED: write_value (depends on Netconversion) *)
-(*
 exception Line_too_long
   (** Raised when the hard limit of the line length is exceeded *)
 
@@ -921,7 +919,6 @@ val write_value :
       Nlchannels.out_obj_channel ->
       s_token list ->
         unit
-*)
     (** Writes the list of [s_token] to the [out_obj_channel]. The value
      * is optionally folded into several lines while writing, but this
      * is off by default. To enable folding, pass {b both} [maxlen1] and

--- a/src/nlsendmail.ml
+++ b/src/nlsendmail.ml
@@ -1,0 +1,388 @@
+(* $Id: netsendmail.ml 1588 2011-04-28 13:59:54Z gerd $
+ * ----------------------------------------------------------------------
+ *
+ * Adapted to netstring-light. Removed the dependency to Netconversion, by
+ * assuming everything to be in UTF-8.
+ *)
+
+open Nlchannels
+open Nlmime
+open Nlmimestring
+
+let sendmail_program = "/usr/lib/sendmail" ;;
+
+
+let default_encoding = "UTF-8"
+
+
+let only_usascii_re = Nlstring_str.regexp "^[\001-\127]*$";;
+
+let specials_re = 
+  Nlstring_str.regexp "[]<>\"\\,()@;:.[/=?]"
+    (* PCRE: "[\\<\\>\\\"\\\\\\,\\(\\)\\@\\;\\:\\.\\[\\]\\/\\=\\?]" *)
+
+let exists rex s =
+  try 
+    ignore(Nlstring_str.search_forward rex s 0); true
+  with
+      Not_found -> false
+;;
+
+let ws_re = Nlstring_str.regexp "[ \t\r\n]+"
+
+let create_address_tokens
+    (hr_addr, formal_addr)=
+  (* Generates addresses like "Gerd Stolpmann <gerd@gerd-stolpmann.de>".
+   * hr_addr is the "human readable" part, and formal_addr is the formal
+   * address. hr_addr must be encoded by [charset].
+   *)
+  let hr_words =
+    if Nlstring_str.string_match only_usascii_re hr_addr 0 <> None then begin
+      (* Use double quotes to protect meta characters *)
+      if exists specials_re hr_addr then
+	[Nlmimestring.QString hr_addr]
+      else 
+	List.map
+	  (fun s -> Nlmimestring.Atom s)
+	  (Nlstring_str.split ws_re hr_addr)
+    end
+    else
+      [Nlmimestring.EncodedWord((default_encoding,""),
+			      "Q", 
+			      hr_addr)]
+  in
+  (* TODO: Check syntax of formal_addr *)
+  let formal_words =
+    [ Nlmimestring.Special '<'; 
+      Nlmimestring.Atom formal_addr; 
+      Nlmimestring.Special '>'
+    ] in
+  (hr_words @ [ Nlmimestring.Special ' ' ] @ formal_words)
+;;
+
+
+let create_address_list_tokens addrs =
+  let rec map addrs =
+    match addrs with
+	[] -> []
+      | addr :: (addr' :: _ as addrs') ->
+	  create_address_tokens addr @ 
+	  [ Nlmimestring.Special ','; Nlmimestring.Special ' ' ] @
+	  map addrs'
+      | [ addr ] ->
+	  create_address_tokens addr
+  in
+  map addrs
+;;
+
+
+let format_field_value fieldname tokens =
+  let val_buf = Buffer.create 80 in
+  let val_ch = new output_buffer val_buf in
+  let maxlen = 78 in
+  let hardmaxlen = 998 in
+  let initlen = String.length fieldname + 2 in  (* String.length ": " = 2 *)
+  Nlmimestring.write_value 
+    ~maxlen1:(maxlen - initlen)
+    ~maxlen
+    ~hardmaxlen1:(hardmaxlen - initlen)
+    ~hardmaxlen
+    val_ch
+    tokens;
+  Buffer.contents val_buf
+;;
+
+
+let create_text_tokens
+      value =
+  let words =
+    if Nlstring_str.string_match only_usascii_re value 0 <> None then
+      List.map (fun s -> Atom s) (Nlstring_str.split ws_re value)
+    else
+      [ Nlmimestring.EncodedWord((default_encoding,""), 
+			         "Q", 
+			         value) ]
+  in
+  words
+;;
+
+
+
+(* Criterions for fields in [fields_to_remove]:
+ *
+ * We want that the message appears as a new message. Because of this
+ * all delivery and transport-related fields are removed. This also
+ * includes delivery and error notifications, transfer priorities,
+ * mailing list information, and local status fields.
+ *
+ * We keep all content-related fields. Sometimes it is difficult to
+ * distinguish between content and transfer fields, especially for
+ * the non-standard fields.
+ *
+ * Sources:
+ * - RFC 2822
+ * - http://www.dsv.su.se/~jpalme/ietf/mail-headers/mail-headers.html
+ *   (former IETF draft, now expired)
+ * - http://www.cs.tut.fi/~jkorpela/headers.html
+ *)
+let fields_to_remove =
+  [ "date";
+    "from";
+    "sender";
+    "reply-to";
+    "to";
+    "cc";
+    "bcc";
+    "message-id";
+    "in-reply-to";
+    "references";
+    (* but not subject, comments, keywords *)
+    "resent-date";
+    "resent-from";
+    "resent-sender";
+    "resent-to";
+    "resent-cc";
+    "resent-bcc";
+    "resent-message-id";
+    "return-path";
+    "received";
+    (* non-standard, or other RFCs but frequently used: *)
+    "alternate-recipient";
+    "x-rcpt-to";
+    "x-sender";
+    "x-x-sender";
+    "envelope-to";
+    "x-envelope-to";
+    "envelope-from";
+    "x-envelope-from";
+    "errors-to";
+    "return-receipt-to";
+    "read-receipt-to";
+    "x-confirm-reading-to";
+    "return-receipt-requested";
+    "registered-mail-reply-requested-by";
+    "delivery-date";
+    "delivered-to";
+    "x-loop";
+    "precedence";
+    "priority";   (* but not "importance" *)
+    "x-msmail-priority";
+    "x-priority";
+    "apparently-to";
+    "posted-to";
+    "content-return";
+    "x400-content-return";
+    "disposition-notification-options";
+    "disposition-notification-to";
+    "generate-delivery-report";
+    "original-recipient";
+    "prevent-nondelivery-report";
+    "mail-reply-to";
+    "x-uidl";
+    "x-imap";
+    "x-mime-autoconverted";
+    "list-archive";
+    "list-digest";
+    "list-help";
+    "list-id";
+    "mailing-list";
+    "x-mailing-list";
+    "list-owner";
+    "list-post";
+    "list-software";
+    "list-subscribe";
+    "list-unsubscribe";
+    "list-url";
+    "x-listserver";
+    "x-list-host";
+    "status";
+  ]
+;;
+
+
+let wrap_mail
+      ?from_addr ?(cc_addrs = []) ?(bcc_addrs = []) 
+      ~to_addrs ~subject (msg : complex_mime_message) : complex_mime_message =
+
+  let (main_hdr, main_body) = msg in
+  let main_hdr' =
+    new basic_mime_header main_hdr#fields in
+  List.iter main_hdr'#delete_field fields_to_remove;
+  let set_field_toks f toks =
+    main_hdr' # update_field f (format_field_value f toks)
+  in
+  ( match from_addr with
+	None -> ()
+      | Some a -> 
+	  set_field_toks "From" 
+	    (create_address_list_tokens [ a ])
+  );
+  set_field_toks "To" 
+    (create_address_list_tokens to_addrs);
+  if cc_addrs <> [] then
+    set_field_toks "Cc" 
+      (create_address_list_tokens cc_addrs);
+  if bcc_addrs <> [] then
+    set_field_toks "Bcc" 
+      (create_address_list_tokens bcc_addrs);
+  set_field_toks "Subject" 
+    (create_text_tokens subject);
+  main_hdr' # update_field "MIME-Version" "1.0";
+  main_hdr' # update_field "X-Mailer" "OcamlNet (ocamlnet.sourceforge.net)";
+  main_hdr' # update_field "Date" 
+    (Nldate.mk_mail_date ~zone:Nldate.localzone (Unix.time()));
+  (main_hdr', main_body)
+;;
+
+
+let create_header 
+      ?content_id
+      ?content_description
+      ?content_location
+      ?content_disposition
+      (ct_type, params) =
+  let hdr = new basic_mime_header [] in
+  let set_field_toks f toks =
+    hdr # update_field f (format_field_value f toks)
+  in
+  
+  let toks = Atom ct_type :: param_tokens ~maxlen:60 params in
+  set_field_toks "Content-type" toks;
+  
+  (* Set Content-ID: *)
+  ( match content_id with
+	None -> ()
+      | Some cid ->
+	  set_field_toks "Content-ID" [Atom ("<" ^ cid ^ ">")]
+  );
+  
+  (* Set Content-Description: *)
+  ( match content_description with
+	None -> ()
+      | Some d ->
+	  set_field_toks "Content-Description" 
+	    (create_text_tokens d);
+  );
+
+  (* Set Content-Location: *)
+  ( match content_location with
+	None -> ()
+      | Some loc ->
+	  set_field_toks "Content-Location" 
+	    (split_uri loc)
+  );
+
+  (* Set Content-Disposition: *)
+  ( match content_disposition with
+	None -> ()
+      | Some (d_main, d_params) ->
+	  set_field_toks "Content-Disposition"
+	    (Atom d_main :: param_tokens ~maxlen:60 d_params)
+  );
+
+  hdr
+;;
+
+
+let wrap_parts
+      ?(content_type = ("multipart/mixed", []))
+      ?content_id
+      ?content_description
+      ?content_location
+      ?content_disposition
+      elements =
+
+  if elements = [] then
+    failwith "Nlsendmail.wrap_parts";
+
+  (* Check Content-type: *)
+  let (ct_type, params) = content_type in
+  let (main_type, sub_type) = split_mime_type ct_type in
+  if main_type <> "multipart" && main_type <> "message" then
+    failwith "Nlsendmail.wrap_parts";
+
+  let hdr =
+    create_header
+      ?content_id ?content_description
+      ?content_location ?content_disposition (ct_type, params) in
+
+  (hdr, `Parts elements)
+;;
+
+
+let wrap_attachment 
+      ?content_id
+      ?content_description
+      ?content_location
+      ?content_disposition
+      ~content_type
+      body =
+
+  let hdr =
+    create_header
+      ?content_id ?content_description
+      ?content_location ?content_disposition content_type in
+
+  (* Set Content-transfer-encoding: *)
+  let (ct_type, params) = content_type in
+  let (main_type, sub_type) = split_mime_type ct_type in
+  let cte =
+    match main_type with
+	"text" -> "quoted-printable"
+      | "multipart"
+      | "message" -> "binary"  (* Don't know better *)
+      | _ -> "base64"
+  in
+  hdr # update_field "Content-transfer-encoding" cte;
+
+  (hdr, `Body body)
+;;
+
+
+let compose
+      ?from_addr ?(cc_addrs = []) ?(bcc_addrs = []) 
+      ?content_type
+      ?(container_type = ("multipart/mixed" , []))
+      ?(attachments = ([] : complex_mime_message list))
+      ~to_addrs ~subject body : complex_mime_message =
+
+
+  (* Set Content-type: *)
+  let (ct_type, params) =
+    ( match content_type with
+	  None ->
+	    ("text/plain", [ "charset",
+			     mk_param default_encoding ])
+	| Some (ct_type, params) ->
+	    (ct_type, params)
+    ) in
+
+  let (main_hdr, main_body) =
+    wrap_attachment 
+      ~content_type:(ct_type, params)
+      (new memory_mime_body body)
+  in
+
+  (* Generate the container for attachments: *)
+  let mail_hdr, mail_body =
+    if attachments = [] then 
+      (main_hdr, main_body)
+    else (
+      wrap_parts
+	~content_type:container_type 
+	( (main_hdr, main_body) :: attachments )
+    )
+  in	  
+  wrap_mail ?from_addr ~to_addrs ~cc_addrs ~bcc_addrs
+            ~subject (mail_hdr, mail_body)
+;;
+
+
+let sendmail ?(mailer = sendmail_program) ?(crlf = false) message =
+  let cmd = mailer ^ " -B8BITMIME -t -i" in
+  with_out_obj_channel
+    (new output_command cmd)
+    (fun ch ->
+       write_mime_message ~crlf ch message;
+    )
+;;

--- a/src/nlsendmail.mli
+++ b/src/nlsendmail.mli
@@ -1,0 +1,331 @@
+(* $Id: netsendmail.mli 1206 2008-10-23 13:51:12Z gerd $
+ * ----------------------------------------------------------------------
+ *
+ *)
+
+(** Functions to compose and send electronic mails 
+ *
+ * {b Contents}
+ *
+ * - {!Nlsendmail.composing} 
+ * - {!Nlsendmail.sending}
+ *
+ * The tutorial has been moved to {!Nlsendmail_tut}.
+ *
+ * Adapted to netstring-light. Removed the dependency to Netconversion, by
+ * assuming everything to be in UTF-8.
+ *)
+
+
+(** {1:composing Composing Messages} 
+ *
+ * The core function is {!Nlsendmail.compose} generating a MIME mail.
+ * The mail can be sent with {!Nlsendmail.sendmail}, written to an
+ * object channel with {!Nlmime.write_mime_message}, or postprocessed
+ * by a user function.
+ *
+ * The call to [compose] can be as easy as
+ *
+ * {[ compose ~from_addr:("me", "me\@domain.net") 
+ *            ~to_addrs:["you", "you\@domain.com"]
+ *            ~subject:"I have a message for you"
+ *            "Hello, this is my message!\n"
+ * ]}
+ *
+ * This call generates the message as {!Nlmime.complex_mime_message},
+ * and can be directly sent with {!Nlsendmail.sendmail}.
+ *
+ * The [compose] function is the simplified interface; alternatively one
+ * can also generate the mail by calling {!Nlsendmail.wrap_mail},
+ * {!Nlsendmail.wrap_parts}, and {!Nlsendmail.wrap_attachment}, getting
+ * more fine-grained control of certain options.
+ *)
+
+val compose :
+      ?from_addr:(string * string) ->
+      ?cc_addrs:(string * string) list ->
+      ?bcc_addrs:(string * string) list ->
+      ?content_type:(string * (string * Nlmimestring.s_param) list) ->
+      ?container_type:(string * (string * Nlmimestring.s_param) list) ->
+      ?attachments:Nlmime.complex_mime_message list ->
+      to_addrs:(string * string) list ->
+      subject:string ->
+      (* text:*) string ->
+	Nlmime.complex_mime_message
+  (** Composes a mail message with a main text, and optionally
+   * a number of attachments.
+   *
+   * The addresses [from_addr], [to_addrs], [cc_addrs], and [bcc_addrs] are
+   * passed as pairs [(human_readable,formal)] where
+   * [human_readable] is an arbitrary printable string identifying the
+   * sender/receiver, and where [formal] is the RFC-822 mailbox specification.
+   * An example is [("Stolpmann, Gerd", "gerd\@gerd-stolpmann.de")].
+   *
+   * The [subject] can be any text.
+   *
+   * The anonymous [string] argument is the main text of the mail.
+   * 
+   * The resulting message is always a correct MIME message.
+   *
+   * @param in_charset All passed texts (except the formal addresses) must
+   *    be encoded in [in_charset]. Default: [`Enc_iso88591].
+   *    As another exception, setting [content_type] explicitly prevents
+   *    the main text from being converted, and [in_charset] does not
+   *    have a meaning for the main text.
+   * @param out_charset The encoded words in the generated header fields,
+   *    if necessary, and the main text are encoded in [out_charset]. 
+   *    Default: [`Enc_iso88591].
+   *    It is required that [out_charset] is ASCII-compatible.
+   *    As a special rule, setting [content_type] explicitly prevents
+   *    the main text from being converted to [out_charset].
+   * @param content_type The content type of the main text. The list is
+   *    the list of parameters attached
+   *    to the type, e.g. [("text/plain", ["charset", mk_param "ISO-8859-1"])]
+   *    (see {!Nlmimestring.mk_param}). When this argument is set,
+   *    the main text is no longer converted to [out_charset].
+   *    By default, when this argument is missing, the main text is
+   *    converted from [in_charset] to [out_charset], and the 
+   *    content type becomes ["text/plain; charset=<out_charset>"].
+   * @param container_type The content type of the container wrapping the
+   *    main text and the attachment into one entity
+   *    (only used if [attachments] are present). This
+   *    defaults to [("multipart/mixed", [])]. This must be either a
+   *    "multipart" or "message" type.
+   * @param attachments An optional list of attachments. Should be generated
+   *    with [wrap_attachment].
+   *)
+
+(** {b Character Set Conversion}
+ *
+ * The impact of [in_charset] and [out_charset] on the generated mail
+ * is not very obvious. The charset arguments may have an effect on
+ * the mail header and the mail body.
+ *
+ * The mail header can only be composed of ASCII characters (7 bit).
+ * To circumvent this restriction the MIME standard specifies a special
+ * format, the so-called encoded words. These may only be used in some
+ * places, and [compose] knows where: In the subject, and the non-formal 
+ * part of mail addresses. The [out_charset] is the character set
+ * used in the generated mail. The [in_charset] is the character set
+ * the strings are encoded you pass to [compose]. It is a good idea
+ * to have [in_charset = out_charset], or at least choose [out_charset] 
+ * as a superset of [in_charset], because this ensures that the character
+ * set conversion succeeds.
+ *
+ * If the mail header does not make use of the additional non-ASCII
+ * characters, the encoded words will be avoided.
+ *
+ * The mail body is only subject of character set conversion if 
+ * the [content_type] is {b not} passed to [compose]. In this case,
+ * the function sets it to [text/plain], and converts the message
+ * from [in_charset] to [out_charset].
+ *
+ * {b Adding Attachments}
+ *
+ * To generate the attachments, call {!Nlsendmail.wrap_attachment}, e.g.
+ *
+ * {[ compose ...
+ *      ~attachments:[ wrap_attachment  
+ *                       ~content_type:("application/octet-stream", [])
+ *                       (new Nlmime.file_mime_body "file.tar.gz") ]
+ * ]}
+ *
+ * There
+ * are a number of kinds of attaching files, identified by [container_type].
+ * The default is [multipart/mixed], meaning that the parts of the mail are
+ * mixed messages and files. One can give a hint whether to display
+ * the parts directly in the mailer program (so-called inline attachments),
+ * or whether to suggest that the file is saved to disk ("real"
+ * attachments). This hint is contained in the [Content-disposition]
+ * header, see [wrap_attachment] how to set it.
+ *
+ * For a discusion of the other [container_type]s see the
+ * {!Nlsendmail.tutorial} at the end of this document.
+ *)
+
+
+val wrap_attachment : 
+      ?content_id:string ->
+      ?content_description:string ->
+      ?content_location:string ->
+      ?content_disposition:(string * (string * Nlmimestring.s_param) list) ->
+      content_type:(string * (string * Nlmimestring.s_param) list) ->
+      Nlmime.mime_body ->
+	Nlmime.complex_mime_message
+  (** Generates a header for the [mime_body]. The returned value
+   * is intended to be used as input for the [attachments] argument
+   * of the [compose] function:
+   *
+   * {[
+   * compose ...
+   *    ~attachments:[ wrap_attachment
+   *                      ~content_type:("audio/wav", [])
+   *                      (new file_mime_body "music.wav") ]
+   * ]}
+   *
+   * The header contains at least the [Content-type] and the
+   * [Content-transfer-encoding] fields. The latter is currently
+   * always ["base64"], but it is possible that the function is
+   * changed in the future to also generate ["quoted-printable"]
+   * when applicable.
+   *
+   * @param in_charset The encoding of the [content_description] argument.
+   *   Default: [`Enc_iso88591].
+   * @param out_charset The encoding of the generated [Content-Description]
+   *    header. Default: [`Enc_iso88591].
+   * @param content_type Specifies the content type with main
+   *   type and list of parameters. Example:
+   *   [ ("text/plain", ["charset", Nlmimestring.mk_param "ISO-8859-1" ]) ]
+   *   (see {!Nlmimestring.mk_param})
+   * @param content_disposition Optionally sets the [Content-disposition]
+   *   header. Frequent values are
+   *   - [ ("inline", []) ]: Indicates that the attachment is displayed
+   *     together with the main text
+   *   - [ ("attachment", ["filename", Nlmimestring.mk_param fn]) ]: Indicates
+   *     that the attachment should be stored onto the disk. The
+   *     parameter [fn] is the suggested file name. Note that [fn]
+   *     should only consist of ASCII characters unless the [charset]
+   *     argument of [mk_param] is set to a different character encoding.
+   * @param content_id Optionally sets the [Content-ID] header field.
+   *   The passed string is the ID value without the embracing angle
+   *   brackets. The [Content-ID] can be used to refer to the attachment
+   *   from other parts of the mail, e.g. in [multipart/related] mails
+   *   HTML documents can include hyperlinks to attachments using the
+   *   URL syntax [cid:ID] where [ID] is the ID value.
+   * @param content_description The [Content-Description] header
+   * @param content_location The [Content-Location] header. This must be
+   *   a valid URL, only composed of 7 bit characters, and with escaped
+   *   unsafe characters
+   *)
+
+val wrap_mail :
+      ?from_addr:(string * string) ->
+      ?cc_addrs:(string * string) list ->
+      ?bcc_addrs:(string * string) list ->
+      to_addrs:(string * string) list ->
+      subject:string ->
+      Nlmime.complex_mime_message ->
+	Nlmime.complex_mime_message
+  (** Sets the mail-related header fields in the input message, and
+   * returns a message ready for delivery. Transfer- and delivery-related 
+   * header fields are removed from the message first, and the new fields
+   * are set to the values passed to this function.
+   *
+   * The arguments are like in {!Nlsendmail.compose}.
+   *
+   * The input message should have at least a [Content-type] header,
+   * but this is not enforced.
+   *
+   * Use this function as an alternative to {!Nlsendmail.compose},
+   * if the message is already available as [complex_mime_message],
+   * e.g. to re-send a parsed mail message to a new destination.
+   *)
+
+(** {b Note: Resending Messages}
+ *
+ * Note that mails generated by [wrap_mail] always appear as new mails,
+ * not as forwarded or replied mails. In order to do the latter a different
+ * way of processing the message is needed.
+ *)
+
+
+val wrap_parts :
+      ?content_type:(string * (string * Nlmimestring.s_param) list) ->
+      ?content_id:string ->
+      ?content_description:string ->
+      ?content_location:string ->
+      ?content_disposition:(string * (string * Nlmimestring.s_param) list) ->
+      Nlmime.complex_mime_message list ->
+	Nlmime.complex_mime_message
+  (** Generates an intermediate container for multipart attachments.
+   * Use this if you want to bundle a set of attachments as a single
+   * attachment.
+   *
+   * @param in_charset The encoding of the [content_description] argument.
+   *   Default: [`Enc_iso88591].
+   * @param out_charset The encoding of the generated [Content-Description]
+   *    header. Default: [`Enc_iso88591].
+   * @param content_type The [Content-Type] header. Default: multipart/mixed
+   * @param content_id The [Content-ID] header, without the angle brackets
+   * @param content_description The [Content-Description] header
+   * @param content_location The [Content-Location] header. This must be
+   *   a valid URL, only composed of 7 bit characters, and with escaped
+   *   unsafe characters
+   * @param content_disposition The [Content-Disposition] header
+   *)
+
+(** {b Low-level} *)
+
+val create_address_list_tokens :
+      (string * string) list ->
+	Nlmimestring.s_token list
+  (** Returns the list of [s_token]s representing email addresses as
+   * structured value. The addresses are passed as list of pairs
+   * [(human_readable, formal)] as in the [compose] function above.
+   * The returned structured field value can be formatted and filled
+   * into a mail header. For example, to set the "To" header to
+   * ["Stolpmann, Gerd" <gerd\@gerd-stolpmann.de>] use
+   * {[
+   * let sval = create_address_list_tokens ["Stolpmann, Gerd",
+   *                                        "gerd\@gerd-stolpmann.de"] in
+   * header # update_field "to" (format_field_value "to" sval)
+   * ]}
+   * This ensures that the field is correctly quoted, that appropriate
+   * encodings are applied and that long values are folded into several
+   * lines.
+   *
+   * @param in_charset The character encoding used for [human_readable].
+   *   Defaults to [`Enc_iso88591].
+   * @param out_charset The character encoding used in the generated
+   *   encoded word. This encoding must be ASCII-compatible. Defaults to
+   *   [`Enc_iso88591].
+   *)
+
+
+val create_text_tokens :
+      string ->
+	Nlmimestring.s_token list
+  (** Returns the list of [s_token]s representing an informal text
+   * as structured value. The text is passed as simple string.
+   * The returned structured field value can be formatted and filled
+   * into a mail header. For example, to set the "Subject" header to
+   * ["I have to say something"], use
+   * {[
+   * let sval = create_text_tokens "I have to say something" in
+   * header # update_field "subject" (format_field_value "subject" sval)
+   * ]}
+   * This ensures that the field is correctly quoted, that appropriate
+   * encodings are applied and that long values are folded into several
+   * lines.
+   *
+   * @param in_charset The character encoding used for the input string.
+   *   Defaults to [`Enc_iso88591].
+   * @param out_charset The character encoding used in the generated
+   *   encoded words. This encoding must be ASCII-compatible. Defaults to
+   *   [`Enc_iso88591].
+   *)
+
+val format_field_value : string -> Nlmimestring.s_token list -> string
+  (** To put [sval], an [s_token list], into the header field [name],
+   * call
+   *
+   * [ header # update_field name (format_field_value name sval) ]
+   *
+   * The field value is folded into several lines, if necessary.
+   *) 
+
+
+(** {1:sending Sending Messages} *)
+
+val sendmail : ?mailer:string -> ?crlf:bool -> Nlmime.complex_mime_message -> unit
+  (** Sends the passed message. The mailer program must be sendmail-compatible
+   * (this can be assumed on all Unix systems, even if a non-sendmail
+   * mailer is installed).
+   *
+   * The mailer program is the command passed as [mailer], which is by
+   * default a reasonable compile-time setting.
+   *
+   * With [crlf] one can determine the EOL convention for the message piped to
+   * the mailer program: If [crlf], CR/LF is used, if [not crlf], only LF is
+   * used. The default is [false] for Unix systems.
+   *)


### PR DESCRIPTION
Port `Netsendmail` into `Nlsendmail`.
Removed the original dependency to `Netconversion` by assuming UTF-8 all the time.
